### PR TITLE
Fix find_min call

### DIFF
--- a/cpp/src/tdoa_dlib_solver.cpp
+++ b/cpp/src/tdoa_dlib_solver.cpp
@@ -67,8 +67,7 @@ dlib::matrix<double, 6, 1> solve_tdoa_dlib(const TDOASet& tdoa, const SourceSet&
         bfgs_search_strategy(),
         objective_delta_stop_strategy(1e-9),
         loss,
-        x,
-        -1 // minimize
+        x
     );
 
     return x;


### PR DESCRIPTION
## Summary
- fix argument list in `tdoa_dlib_solver.cpp`

## Testing
- `python3 -m py_compile python/*.py`